### PR TITLE
feat: query vaults & nodes by tags

### DIFF
--- a/src/api/akord-api.ts
+++ b/src/api/akord-api.ts
@@ -244,42 +244,44 @@ export default class AkordApi extends Api {
     return contract.state;
   };
 
-  public async getMemberships(limit?: number, nextToken?: string): Promise<Paginated<Membership>> {
+  public async getMemberships(options: ListOptions = {}): Promise<Paginated<Membership>> {
     return await new ApiClient()
       .env(this.config)
       .queryParams({
-        limit,
-        nextToken
+        limit: options.limit,
+        nextToken: options.nextToken
       })
       .getMemberships();
   };
 
-  public async getVaults(filter = {}, limit?: number, nextToken?: string): Promise<Paginated<Vault>> {
+  public async getVaults(options: ListOptions = {}): Promise<Paginated<Vault>> {
     return await new ApiClient()
       .env(this.config)
       .queryParams({
-        filter: JSON.stringify(filter),
-        limit,
-        nextToken
+        tags: options.tags,
+        filter: JSON.stringify(options.filter ? options.filter : {}),
+        limit: options.limit,
+        nextToken: options.nextToken
       })
       .getVaults();
   };
 
-  public async getNodesByVaultId<T>(vaultId: string, type: NodeType, options: ListOptions): Promise<Paginated<T>> {
+  public async getNodesByVaultId<T>(vaultId: string, type: NodeType, options: ListOptions = {}): Promise<Paginated<T>> {
     return await new ApiClient()
       .env(this.config)
       .vaultId(vaultId)
       .queryParams({
         type,
         parentId: options.parentId,
+        tags: options.tags,
         filter: JSON.stringify(options.filter ? options.filter : {}),
         limit: options.limit,
         nextToken: options.nextToken
       })
-      .getNodesByVaultId();
+      .getNodesByVaultId<T>();
   };
 
-  public async getMembershipsByVaultId(vaultId: string, options: ListOptions): Promise<Paginated<Membership>> {
+  public async getMembershipsByVaultId(vaultId: string, options: ListOptions = {}): Promise<Paginated<Membership>> {
     return await new ApiClient()
       .env(this.config)
       .vaultId(vaultId)

--- a/src/api/akord-api.ts
+++ b/src/api/akord-api.ts
@@ -258,7 +258,7 @@ export default class AkordApi extends Api {
     return await new ApiClient()
       .env(this.config)
       .queryParams({
-        tags: options.tags,
+        tags: JSON.stringify(options.tags ? options.tags : {}),
         filter: JSON.stringify(options.filter ? options.filter : {}),
         limit: options.limit,
         nextToken: options.nextToken
@@ -273,7 +273,7 @@ export default class AkordApi extends Api {
       .queryParams({
         type,
         parentId: options.parentId,
-        tags: options.tags,
+        tags: JSON.stringify(options.tags ? options.tags : {}),
         filter: JSON.stringify(options.filter ? options.filter : {}),
         limit: options.limit,
         nextToken: options.nextToken

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -41,9 +41,9 @@ abstract class Api {
 
   abstract getNodeState(stateId: string): Promise<any>
 
-  abstract getVaults(filter?: Object, limit?: number, nextToken?: string): Promise<Paginated<Vault>>
+  abstract getVaults(options?: ListOptions): Promise<Paginated<Vault>>
 
-  abstract getMemberships(limit?: number, nextToken?: string): Promise<Paginated<Membership>>
+  abstract getMemberships(options?: ListOptions): Promise<Paginated<Membership>>
 
   abstract getNodesByVaultId<T>(vaultId: string, type: string, options?: ListOptions): Promise<Paginated<T>>
 

--- a/src/core/profile.ts
+++ b/src/core/profile.ts
@@ -67,7 +67,7 @@ class ProfileService extends Service {
 
   private async listMemberships(): Promise<Array<Membership>> {
     const list = async (listOptions: ListOptions) => {
-      return await this.api.getMemberships(listOptions.limit, listOptions.nextToken);
+      return await this.api.getMemberships(listOptions);
     }
     return await this.paginate<Membership>(list, {});
   }

--- a/src/core/vault.ts
+++ b/src/core/vault.ts
@@ -55,7 +55,7 @@ class VaultService extends Service {
       ...this.defaultListOptions,
       ...options
     }
-    const response = await this.api.getVaults(listOptions.filter, listOptions.limit, listOptions.nextToken);
+    const response = await this.api.getVaults(listOptions);
     const promises = response.items
       .map(async (vaultProto: Vault) => {
         return await this.processVault(vaultProto, listOptions.shouldDecrypt, vaultProto.keys);

--- a/src/types/query-options.ts
+++ b/src/types/query-options.ts
@@ -4,8 +4,13 @@ export type ListOptions = {
   limit?: number, // the limit of the number of items in a query (default to 100)
   nextToken?: string,
   parentId?: string,
-  tags?: string[]
+  tags?: {
+    values: string[],
+    searchCriteria?: SearchCriteria // default to CONTAINS_EVERY
+  }
 }
+
+export type SearchCriteria = "CONTAINS_SOME" | "CONTAINS_EVERY";
 
 export type GetOptions = {
   shouldDecrypt?: boolean,

--- a/src/types/query-options.ts
+++ b/src/types/query-options.ts
@@ -2,8 +2,9 @@ export type ListOptions = {
   shouldDecrypt?: boolean,
   filter?: Object,
   limit?: number, // the limit of the number of items in a query (default to 100)
-  nextToken?: string
-  parentId?: string
+  nextToken?: string,
+  parentId?: string,
+  tags?: string[]
 }
 
 export type GetOptions = {


### PR DESCRIPTION
### list vaults & nodes by tags
search for vaults and nodes by specific tags by passing a [tags object in the list options.
](https://github.com/Akord-com/akord-js/blob/0afc7b59cee67b75a3bee62033263f43c938e797/src/types/query-options.ts#L7)

- list user vaults that contain **_all_** of the given tags:
```js
const vaults = await akord.vault.listAll({
   tags: {
      values: ["jam session", "soul"],
      searchCriteria: "CONTAINS_EVERY"
   }
});
```

- list vault file stacks that contain **_at least one_** of the given tags:
```js
const vaults = await akord.stack.listAll(vaultId, {
   tags: {
      values: ["soul", "jazz", "funk"]
      searchCriteria: "CONTAINS_SOME"
   }
});
```