### PR TITLE
feat: add mising api methods and notification types

### DIFF
--- a/src/api/akord-api.ts
+++ b/src/api/akord-api.ts
@@ -13,13 +13,14 @@ import { ListOptions, VaultApiGetOptions } from "../types/query-options";
 import { User, UserPublicInfo } from "../types/user";
 import { FileDownloadOptions, FileUploadOptions } from "../core/file";
 import { EncryptionMetadata } from "../core";
+import { InAppNotifications } from "../types/in-app-notifications";
 
 export const defaultFileUploadOptions = {
   cacheOnly: false,
   public: false
 };
 
-export default class AkordApi extends Api {
+class AkordApi extends Api {
 
   public config!: ApiConfig;
 
@@ -218,7 +219,7 @@ export default class AkordApi extends Api {
     return response.data
   };
 
-  public async getNotifications(): Promise<Paginated<any>> {
+  public async getNotifications(): Promise<InAppNotifications> {
     return await new ApiClient()
       .env(this.config)
       .getNotifications()

--- a/src/api/api-client.ts
+++ b/src/api/api-client.ts
@@ -11,6 +11,7 @@ import { throwError } from "../errors/error-factory";
 import { BadRequest } from "../errors/bad-request";
 import { NotFound } from "../errors/not-found";
 import { User, UserPublicInfo } from "../types/user";
+import { InAppNotifications } from "../types/in-app-notifications";
 
 export class ApiClient {
   private _storageurl: string;
@@ -173,7 +174,7 @@ export class ApiClient {
     return await this.get(`${this._apiurl}/vaults/${this._vaultId}/members`);
   }
 
-  async getNotifications(): Promise<Paginated<any>> {
+  async getNotifications(): Promise<InAppNotifications> {
     return await this.get(`${this._apiurl}/notifications`);
   }
 

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -7,6 +7,7 @@ import { ListOptions, VaultApiGetOptions } from "../types/query-options";
 import { User, UserPublicInfo } from "../types/user";
 import { FileDownloadOptions, FileUploadOptions } from "../core/file";
 import { EncryptionMetadata } from "../core";
+import { InAppNotifications } from "../types/in-app-notifications";
 
 abstract class Api {
   config: any
@@ -62,6 +63,15 @@ abstract class Api {
   abstract revokeInvite(vaultId: string, membershipId: string): Promise<{ id: string }>
 
   abstract inviteResend(vaultId: string, membershipId: string): Promise<{ id: string }>
+
+  abstract getNotifications(): Promise<InAppNotifications>
+
+  abstract readNotifications(options: {
+    id?: string,
+    vaultId?: string,
+    readOnly?: Boolean,
+    shouldDelete?: Boolean
+  }): Promise<void>
 }
 
 export {

--- a/src/types/in-app-notifications.ts
+++ b/src/types/in-app-notifications.ts
@@ -1,0 +1,47 @@
+import { actionRefs } from "../constants";
+
+export type InAppNotifications = {
+  notifications: Array<Notification>
+  nextToken: string
+}
+
+export type Notification = {
+  admin: boolean;
+  content: any;
+  hash: string;
+  height: string;
+  id: string;
+  dataRoomId: string;
+  modelType: string;
+  modelId: string;
+  status: "READ" | "UNREAD" | "DELETED";
+  createdAt: string;
+  groupRef: string;
+  dataRoom: { memberships: { items: DataRoomMember[] } };
+  transactions: { items: NotificationTransaction[] };
+}
+
+export type DataRoomMember = {
+  id: string;
+  dataRoomId: string;
+  memberPublicSigningKey: string;
+  publicSigningKey: string;
+};
+
+export type NotificationTransaction = {
+  publicSigningKey: string;
+  actionRef: actionRefs;
+  createdAt: string;
+  dataRoomId: string;
+  vaultId: string;
+  modelId: string;
+  objectId: string;
+  objectType: string;
+  groupRef: string;
+  hash: string;
+  encodedPrevState: string;
+  stack: { title: string };
+  folder: { title: string };
+  note: { title: string };
+  memo: { message: string };
+};


### PR DESCRIPTION
Working on updating [InAppNotificationsContext](https://github.com/Akord-com/akord-web/blob/dev/src/contexts/InAppNotificationsContext.jsx). Needed some updates from `akord-js`.
Don't understand what's the deal with this missing method: https://github.com/Akord-com/akord-web/blob/2aea9d35a3005659369661c02058676be701a9c9/src/contexts/InAppNotificationsContext.jsx#L154
Can this be added or not needed? Ticket is here [#640](https://github.com/Akord-com/akord-web/issues/640)